### PR TITLE
Add Instagram Community Guidelines

### DIFF
--- a/declarations/Instagram.filters.js
+++ b/declarations/Instagram.filters.js
@@ -1,0 +1,10 @@
+export function removeTrackingIDs(document) {
+  document.querySelectorAll("a").forEach((el) => {
+    const href = el.getAttribute("href");
+    const params = new URLSearchParams(href);
+    if (params.has("h")) {
+      params.set("h", "removed");
+      el.setAttribute("href", params.toString());
+    }
+  });
+}

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -28,6 +28,12 @@
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
       "executeClientScripts": true
+    },
+    "Community Guidelines - Violence Incitement": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/violence-incitement/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -46,6 +46,12 @@
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
       "executeClientScripts": true
+    },
+    "Community Guidelines - Regulated Goods": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/regulated-goods/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -57,6 +57,17 @@
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/bullying-harassment/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
+    },
+    "Community Guidelines - Intellectual Property": {
+      "fetch": "https://help.instagram.com/126382350847838",
+      "select": ["div[role=\"main\"]"],
+      "remove": [
+        "div[aria-label=\"Copier le lien\"]",
+        "[id='Articles connexes']",
+        "fieldset"
+      ],
+      "filter": ["removeTrackingIDs"],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -22,6 +22,12 @@
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/hate-speech/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
+    },
+    "Community Guidelines - Child Sexual Exploitation": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/child-sexual-exploitation-abuse-nudity/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -17,6 +17,11 @@
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/suicide-self-injury/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
+    },
+    "Community Guidelines - Hate Speech": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/hate-speech/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -26,32 +26,27 @@
     "Community Guidelines - Child Sexual Exploitation": {
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/child-sexual-exploitation-abuse-nudity/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
-      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
-      "executeClientScripts": true
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     },
     "Community Guidelines - Violence Incitement": {
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/violence-incitement/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
-      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
-      "executeClientScripts": true
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     },
     "Community Guidelines - Violent Organizations": {
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/dangerous-individuals-organizations/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
-      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
-      "executeClientScripts": true
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     },
     "Community Guidelines - Spam": {
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/spam/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
-      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
-      "executeClientScripts": true
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     },
     "Community Guidelines - Regulated Goods": {
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/regulated-goods/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
-      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
-      "executeClientScripts": true
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     },
     "Community Guidelines - Harassment": {
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/bullying-harassment/",

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -73,6 +73,11 @@
       "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/adult-nudity-sexual-activity/",
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
+    },
+    "Community Guidelines - Sexual Solicitation": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/sexual-solicitation/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -34,6 +34,12 @@
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
       "executeClientScripts": true
+    },
+    "Community Guidelines - Violent Organizations": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/dangerous-individuals-organizations/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -8,6 +8,10 @@
     "Terms of Service": {
       "fetch": "https://help.instagram.com/581066165581870",
       "select": [".bk"]
+    },
+    "Community Guidelines": {
+      "fetch": "https://help.instagram.com/477434105621119",
+      "select": [".bj", ".bl"]
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -12,6 +12,11 @@
     "Community Guidelines": {
       "fetch": "https://help.instagram.com/477434105621119",
       "select": [".bj", ".bl"]
+    },
+    "Community Guidelines - Self-harm": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/suicide-self-injury/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -68,6 +68,11 @@
       ],
       "filter": ["removeTrackingIDs"],
       "executeClientScripts": true
+    },
+    "Community Guidelines - Adult Nudity": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/adult-nudity-sexual-activity/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -40,6 +40,12 @@
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
       "executeClientScripts": true
+    },
+    "Community Guidelines - Spam": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/spam/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
+      "executeClientScripts": true
     }
   }
 }

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -52,6 +52,11 @@
       "select": ["._9nrm", "._9q49", "._9p7c"],
       "remove": ["._9p72", "svg", "._9ooi", "._9q3_"],
       "executeClientScripts": true
+    },
+    "Community Guidelines - Harassment": {
+      "fetch": "https://transparency.fb.com/fr-fr/policies/community-standards/bullying-harassment/",
+      "select": ["._9nrm", "._9q49", "._9p7c"],
+      "remove": ["._9p72", "svg", "._9ooi", "._9q3_"]
     }
   }
 }


### PR DESCRIPTION
Encountered problems:

1. I can't find a solution to recover the contents of the `Community Guidelines - Misinformation` accordion from this URL`https://fr-fr.facebook.com/help/instagram/1735798276553028/` (linked from the Community Guidelines index).

With the following declaration i get only the accordion sections titles because the relative content is loaded dynamically.

```json
 "Community Guidelines - Misinformation": {
      "fetch": "https://fr-fr.facebook.com/help/instagram/1735798276553028/",
      "select": ["div[role=\"main\"]"],
      "executeClientScripts": true
    }
```

Note that each section of this `Misinformation` document is accessible via a dictinctive URL:
- Section 1: https://fr-fr.facebook.com/help/instagram/2109682462659451/
- Section 2: https://fr-fr.facebook.com/help/instagram/388534952086572/
- Section 3: https://fr-fr.facebook.com/help/instagram/975917226081685/
- Section 4: https://fr-fr.facebook.com/help/instagram/2442045389198631/
- Section 5: https://fr-fr.facebook.com/help/instagram/759619721131409/
- Section 6: https://fr-fr.facebook.com/help/instagram/234606571236360/

2. Meta seems to have a protection against too frequent http calls and after a while I get stuck on a Facebook login page. For exemple, this is a screenshot of my local `Community Guidelines - Hate Speech` snapshot.

![image](https://user-images.githubusercontent.com/364319/158401321-543bb43d-c49d-41d1-82a1-0f92f566b755.png)

3. I don't find some document URL in the Instagram help center: 
- `Community Guidelines - Inauthentic Behaviour and Platform Manipulation`
- `Community Guidelines - Privacy Violations`
- `Community Guidelines - Deceased Users`

