### PR TITLE
Add Twitter Community Guidelines

### DIFF
--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -94,7 +94,7 @@
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
     },
-    "Community Guidelines - Intellectual Property": {
+    "Copyright Claims Policy": {
       "fetch": "https://help.twitter.com/fr/rules-and-policies/copyright-policy",
       "select": ["#twtr-main"],
       "remove": [

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -111,6 +111,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Privacy Violations": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/personal-information",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -48,6 +48,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Violent Incitement": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/glorification-of-violence",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -21,6 +21,15 @@
         ".p22-chapters-container",
         ".cr01-section"
       ]
+    },
+    "Community Guidelines - Self-harm": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/glorifying-self-harm",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -30,6 +30,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Hate Speech": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/hateful-conduct-policy",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -84,6 +84,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Harassment": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/abusive-behavior",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -22,6 +22,15 @@
         ".cr01-section"
       ]
     },
+    "Community Guidelines": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/twitter-rules",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
+    },
     "Community Guidelines - Self-harm": {
       "fetch": "https://help.twitter.com/fr/rules-and-policies/glorifying-self-harm",
       "select": ["#twtr-main"],
@@ -94,15 +103,6 @@
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
     },
-    "Copyright Claims Policy": {
-      "fetch": "https://help.twitter.com/fr/rules-and-policies/copyright-policy",
-      "select": ["#twtr-main"],
-      "remove": [
-        ".u11__breadcrumbs",
-        ".b24-share-tweet",
-        ".b01__headline.twtr-type--headline-md.inherit"
-      ]
-    },
     "Community Guidelines - Inauthentic Behaviour and Platform Manipulation": {
       "fetch": "https://help.twitter.com/fr/rules-and-policies/platform-manipulation",
       "select": ["#twtr-main"],
@@ -121,8 +121,8 @@
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
     },
-    "Deceased Users": {
-      "fetch": "https://help.twitter.com/fr/rules-and-policies/contact-twitter-about-media-on-a-deceased-family-members-account",
+    "Copyright Claims Policy": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/copyright-policy",
       "select": ["#twtr-main"],
       "remove": [
         ".u11__breadcrumbs",
@@ -130,8 +130,8 @@
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
     },
-    "Community Guidelines": {
-      "fetch": "https://help.twitter.com/fr/rules-and-policies/twitter-rules",
+    "Deceased Users": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/contact-twitter-about-media-on-a-deceased-family-members-account",
       "select": ["#twtr-main"],
       "remove": [
         ".u11__breadcrumbs",

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -102,6 +102,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Inauthentic Behaviour and Platform Manipulation": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/platform-manipulation",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -66,6 +66,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Spam": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/platform-manipulation",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -93,6 +93,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Intellectual Property": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/copyright-policy",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -129,6 +129,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/twitter-rules",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -57,6 +57,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Violent Organizations": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/violent-groups",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -75,6 +75,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Regulated Goods": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/regulated-goods-services",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -120,6 +120,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Deceased Users": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/contact-twitter-about-media-on-a-deceased-family-members-account",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }

--- a/declarations/Twitter.json
+++ b/declarations/Twitter.json
@@ -39,6 +39,15 @@
         ".b24-share-tweet",
         ".b01__headline.twtr-type--headline-md.inherit"
       ]
+    },
+    "Community Guidelines - Child Sexual Exploitation": {
+      "fetch": "https://help.twitter.com/fr/rules-and-policies/sexual-exploitation-policy",
+      "select": ["#twtr-main"],
+      "remove": [
+        ".u11__breadcrumbs",
+        ".b24-share-tweet",
+        ".b01__headline.twtr-type--headline-md.inherit"
+      ]
     }
   }
 }


### PR DESCRIPTION
According to the[ Community guidelines ontology](https://github.com/ambanum/OpenTermsArchive/issues/773), these are missing documents:
- [Platform Use Guidelines - About specific instances when a Tweet’s reach may be limited](https://help.twitter.com/fr/rules-and-policies/twitter-reach-limited) because `Reach Amplification` document type is not available
- [Platform Use Guidelines - Updates to our Terms of Service and Privacy Policy](https://help.twitter.com/fr/rules-and-policies/update-privacy-policy) because `Terms Updates` document type is not available

Note that `Community Guidelines - Spam` and `Community Guidelines - Inauthentic Behaviour and Platform Manipulation` are the same document and the content does not allow the targeting of separate parts for each type.
